### PR TITLE
Fix reflection warnings in http-client

### DIFF
--- a/src/com/grzm/awyeah/http_client.clj
+++ b/src/com/grzm/awyeah/http_client.clj
@@ -110,11 +110,13 @@
              (HttpRequest$BodyPublishers/ofByteArray (byte-buffer->byte-array body))
              (HttpRequest$BodyPublishers/noBody))
         builder (-> (HttpRequest/newBuilder uri)
-                    (.method ^String method bp))]
-    (.build (cond-> builder
-              (seq headers) (add-headers headers)
-              (::timeout-msec m) (.timeout (Duration/ofMillis
-                                             (::timeout-msec m)))))))
+                    (.method ^String method bp))
+        builder (if (seq headers) (add-headers builder headers) builder)
+        builder (if-let [timeout (::timeout-msec m)]
+                  (.timeout ^HttpRequest$Builder builder
+                            (Duration/ofMillis timeout))
+                  builder)]
+    (.build ^HttpRequest$Builder builder)))
 
 (defn error->anomaly [^Throwable t]
   {:cognitect.anomalies/category :cognitect.anomalies/fault


### PR DESCRIPTION
I was seeing some reflection warnings in here but these changes eliminated them. The code is not as nice, but I've never figured out how to type hint the threaded arg in `->` / `cond->` style macros (`as->` works great for this but there is no `cond-as->`).